### PR TITLE
Dropped Colab's bootstrap JS

### DIFF
--- a/src/colab_mezuro/diazo.xml
+++ b/src/colab_mezuro/diazo.xml
@@ -13,6 +13,6 @@
     <merge attributes="data-project-id" css:theme="body" css:content="body" />
 
     <drop css:content=".navbar" /> <!-- Mezuro's navbar links are part of Colab's menu -->
-    <drop css:theme="script[src$='bootstrap.min.js']" /> <!-- Fixes top menu dropdown by removing Colab's bootstrap JS -->
+    <drop css:theme="script[src*='bootstrap']" /> <!-- Fixes top menu dropdown by removing Colab's bootstrap JS -->
     <drop css:theme="script[src*='jquery']:not([src*='cookie']):not([src*='debouncedresize'])" /> <!-- Fixes accordion conflict by removing Colab's JQuery. But keeps the JS for cookie and debouncedresize -->
 </rules>


### PR DESCRIPTION
Not using hard coded minified version to be dropped, but any bootstrap js that Colab might be using
