### PR TITLE
Stop dropping the menu

### DIFF
--- a/src/colab_mezuro/diazo.xml
+++ b/src/colab_mezuro/diazo.xml
@@ -12,7 +12,6 @@
     <merge attributes="data-page" css:theme="body" css:content="body" />
     <merge attributes="data-project-id" css:theme="body" css:content="body" />
 
-    <drop css:content=".navbar" /> <!-- Mezuro's navbar links are part of Colab's menu -->
     <drop css:theme="script[src*='bootstrap']" /> <!-- Fixes top menu dropdown by removing Colab's bootstrap JS -->
     <drop css:theme="script[src*='jquery']:not([src*='cookie']):not([src*='debouncedresize'])" /> <!-- Fixes accordion conflict by removing Colab's JQuery. But keeps the JS for cookie and debouncedresize -->
 </rules>


### PR DESCRIPTION
The new layout (image below) conciliates the upper menu.

![0](https://cloud.githubusercontent.com/assets/288884/14685112/851227e4-0709-11e6-8f74-ad7e8e5e7ecd.png)
